### PR TITLE
Add Archives pages to publishable content

### DIFF
--- a/app/controllers/francis_cms/archives_controller.rb
+++ b/app/controllers/francis_cms/archives_controller.rb
@@ -2,14 +2,13 @@ require_dependency 'francis_cms/francis_cms_controller'
 
 module FrancisCms
   class ArchivesController < FrancisCmsController
-    def index
-      resource_type
+    include FrancisCms::ApplicationHelper
 
+    def index
       @years = parent_class.years
     end
 
     def show
-      resource_type
       year
 
       @results = parent_class.for_year(@year)
@@ -17,16 +16,8 @@ module FrancisCms
 
     private
 
-    def resource_type
-      @resource_type ||= parent.capitalize.pluralize
-    end
-
-    def parent
-      @parent ||= %w(posts links).find { |p| request.path.split('/').include? p }.singularize
-    end
-
     def parent_class
-      @parent_class ||= "FrancisCms::#{parent.classify}".constantize
+      @parent_class ||= "FrancisCms::#{resource_type.classify}".constantize
     end
 
     def year

--- a/app/controllers/francis_cms/archives_controller.rb
+++ b/app/controllers/francis_cms/archives_controller.rb
@@ -3,13 +3,13 @@ require_dependency 'francis_cms/francis_cms_controller'
 module FrancisCms
   class ArchivesController < FrancisCmsController
     def index
-      content_type
+      resource_type
 
       @years = parent_class.years
     end
 
     def show
-      content_type
+      resource_type
       year
 
       @results = parent_class.for_year(@year)
@@ -17,8 +17,8 @@ module FrancisCms
 
     private
 
-    def content_type
-      @content_type ||= parent.capitalize.pluralize
+    def resource_type
+      @resource_type ||= parent.capitalize.pluralize
     end
 
     def parent

--- a/app/controllers/francis_cms/archives_controller.rb
+++ b/app/controllers/francis_cms/archives_controller.rb
@@ -2,8 +2,6 @@ require_dependency 'francis_cms/francis_cms_controller'
 
 module FrancisCms
   class ArchivesController < FrancisCmsController
-    include FrancisCms::ApplicationHelper
-
     def index
       @years = parent_class.years
     end

--- a/app/controllers/francis_cms/archives_controller.rb
+++ b/app/controllers/francis_cms/archives_controller.rb
@@ -1,0 +1,36 @@
+require_dependency 'francis_cms/francis_cms_controller'
+
+module FrancisCms
+  class ArchivesController < FrancisCmsController
+    def index
+      content_type
+
+      @years = parent_class.years
+    end
+
+    def show
+      content_type
+      year
+
+      @results = parent_class.for_year(@year)
+    end
+
+    private
+
+    def content_type
+      @content_type ||= parent.capitalize.pluralize
+    end
+
+    def parent
+      @parent ||= %w(posts links).find { |p| request.path.split('/').include? p }.singularize
+    end
+
+    def parent_class
+      @parent_class ||= "FrancisCms::#{parent.classify}".constantize
+    end
+
+    def year
+      @year ||= params[:year]
+    end
+  end
+end

--- a/app/controllers/francis_cms/archives_controller.rb
+++ b/app/controllers/francis_cms/archives_controller.rb
@@ -7,8 +7,7 @@ module FrancisCms
     end
 
     def show
-      year
-
+      @year = params[:year]
       @results = parent_class.for_year(@year)
     end
 
@@ -16,10 +15,6 @@ module FrancisCms
 
     def parent_class
       @parent_class ||= "FrancisCms::#{resource_type.classify}".constantize
-    end
-
-    def year
-      @year ||= params[:year]
     end
   end
 end

--- a/app/controllers/francis_cms/francis_cms_controller.rb
+++ b/app/controllers/francis_cms/francis_cms_controller.rb
@@ -5,6 +5,11 @@ module FrancisCms
     end
     helper_method :__logged_in__
 
+    def resource_type
+      %w(posts links).find { |p| request.path.split('/').include? p }
+    end
+    helper_method :resource_type
+
     def require_login
       redirect_to FrancisCms.configuration.login_path unless __logged_in__
     end

--- a/app/controllers/francis_cms/francis_cms_controller.rb
+++ b/app/controllers/francis_cms/francis_cms_controller.rb
@@ -5,13 +5,13 @@ module FrancisCms
     end
     helper_method :__logged_in__
 
+    def require_login
+      redirect_to FrancisCms.configuration.login_path unless __logged_in__
+    end
+
     def resource_type
       %w(posts links).find { |p| request.path.split('/').include? p }
     end
     helper_method :resource_type
-
-    def require_login
-      redirect_to FrancisCms.configuration.login_path unless __logged_in__
-    end
   end
 end

--- a/app/controllers/francis_cms/syndications_controller.rb
+++ b/app/controllers/francis_cms/syndications_controller.rb
@@ -2,6 +2,8 @@ require_dependency 'francis_cms/francis_cms_controller'
 
 module FrancisCms
   class SyndicationsController < FrancisCmsController
+    include FrancisCms::ApplicationHelper
+
     before_action :require_login
 
     def create
@@ -9,27 +11,23 @@ module FrancisCms
 
       @syndication.save
 
-      redirect_to send("edit_#{parent}_path", syndicatable)
+      redirect_to send("edit_#{resource_type.singularize}_path", syndicatable)
     end
 
     def destroy
       syndication.destroy
 
-      redirect_to send("edit_#{parent}_path", syndicatable)
+      redirect_to send("edit_#{resource_type.singularize}_path", syndicatable)
     end
 
     private
 
-    def parent
-      @parent ||= %w(posts links).find { |p| request.path.split('/').include? p }.singularize
-    end
-
     def parent_class
-      @parent_class ||= "FrancisCms::#{parent.classify}".constantize
+      @parent_class ||= "FrancisCms::#{resource_type.classify}".constantize
     end
 
     def syndicatable
-      @syndicatable ||= parent_class.find(params["#{parent}_id"])
+      @syndicatable ||= parent_class.find(params["#{resource_type.singularize}_id"])
     end
 
     def syndication

--- a/app/controllers/francis_cms/syndications_controller.rb
+++ b/app/controllers/francis_cms/syndications_controller.rb
@@ -2,8 +2,6 @@ require_dependency 'francis_cms/francis_cms_controller'
 
 module FrancisCms
   class SyndicationsController < FrancisCmsController
-    include FrancisCms::ApplicationHelper
-
     before_action :require_login
 
     def create

--- a/app/helpers/francis_cms/application_helper.rb
+++ b/app/helpers/francis_cms/application_helper.rb
@@ -6,4 +6,8 @@ module FrancisCms::ApplicationHelper
       raw image_tag(%{data:image/png;base64,#{Base64.encode64 Rails.application.assets['avatar.png'].to_s}}, html_options)
     end
   end
+
+  def resource_type
+    %w(posts links).find { |p| request.path.split('/').include? p }
+  end
 end

--- a/app/helpers/francis_cms/application_helper.rb
+++ b/app/helpers/francis_cms/application_helper.rb
@@ -6,8 +6,4 @@ module FrancisCms::ApplicationHelper
       raw image_tag(%{data:image/png;base64,#{Base64.encode64 Rails.application.assets['avatar.png'].to_s}}, html_options)
     end
   end
-
-  def resource_type
-    %w(posts links).find { |p| request.path.split('/').include? p }
-  end
 end

--- a/app/views/francis_cms/archives/index.html.erb
+++ b/app/views/francis_cms/archives/index.html.erb
@@ -8,7 +8,7 @@
 	<%- if @years.any? -%>
 		<ol class="years-list">
 			<%- @years.each do |year| -%>
-				<li><%= link_to year, send("archives_yearly_#{@content_type.downcase}_path", year) %></li>
+				<li><%= link_to year, send("archives_yearly_#{@content_type.downcase}_path", year), rel: 'archives' %></li>
 			<%- end -%>
 		</ol>
 	<%- else -%>

--- a/app/views/francis_cms/archives/index.html.erb
+++ b/app/views/francis_cms/archives/index.html.erb
@@ -1,17 +1,17 @@
-<%- @page_title = "#{@content_type} Archives" -%>
+<%- @page_title = "#{@resource_type} Archives" -%>
 
 <header class="content-header">
-	<h1><%= @content_type %> Archives</h1>
+	<h1><%= @resource_type %> Archives</h1>
 </header>
 
 <div class="content-container">
 	<%- if @years.any? -%>
 		<ol class="years-list">
 			<%- @years.each do |year| -%>
-				<li><%= link_to year, send("archives_yearly_#{@content_type.downcase}_path", year), rel: 'archives' %></li>
+				<li><%= link_to year, send("archives_yearly_#{@resource_type.downcase}_path", year), rel: 'archives' %></li>
 			<%- end -%>
 		</ol>
 	<%- else -%>
-		<p>No <%= @content_type.downcase %> found!</p>
+		<p>No <%= @resource_type.downcase %> found!</p>
 	<%- end -%>
 </div>

--- a/app/views/francis_cms/archives/index.html.erb
+++ b/app/views/francis_cms/archives/index.html.erb
@@ -1,17 +1,17 @@
-<%- @page_title = "#{@resource_type} Archives" -%>
+<%- @page_title = "#{resource_type.capitalize} Archives" -%>
 
 <header class="content-header">
-	<h1><%= @resource_type %> Archives</h1>
+	<h1><%= resource_type.capitalize %> Archives</h1>
 </header>
 
 <div class="content-container">
 	<%- if @years.any? -%>
 		<ol class="years-list">
 			<%- @years.each do |year| -%>
-				<li><%= link_to year, send("archives_yearly_#{@resource_type.downcase}_path", year), rel: 'archives' %></li>
+				<li><%= link_to year, send("archives_yearly_#{resource_type}_path", year), rel: 'archives' %></li>
 			<%- end -%>
 		</ol>
 	<%- else -%>
-		<p>No <%= @resource_type.downcase %> found!</p>
+		<p>No <%= resource_type %> found!</p>
 	<%- end -%>
 </div>

--- a/app/views/francis_cms/archives/index.html.erb
+++ b/app/views/francis_cms/archives/index.html.erb
@@ -1,0 +1,17 @@
+<%- @page_title = "#{@content_type} Archives" -%>
+
+<header class="content-header">
+	<h1><%= @content_type %> Archives</h1>
+</header>
+
+<div class="content-container">
+	<%- if @years.any? -%>
+		<ol class="years-list">
+			<%- @years.each do |year| -%>
+				<li><%= link_to year, send("archives_yearly_#{@content_type.downcase}_path", year) %></li>
+			<%- end -%>
+		</ol>
+	<%- else -%>
+		<p>No <%= @content_type.downcase %> found!</p>
+	<%- end -%>
+</div>

--- a/app/views/francis_cms/archives/show.html.erb
+++ b/app/views/francis_cms/archives/show.html.erb
@@ -1,0 +1,26 @@
+<%- @page_title = "#{@content_type} Archives: #{@year}" -%>
+
+<div class="h-feed">
+	<header class="content-header">
+		<h1 class="p-name"><%= @content_type %> Archives: <%= @year %></h1>
+	</header>
+
+	<div class="content-container">
+		<%- if @results.any? -%>
+			<ol class="entries">
+				<%- @results.each do |result| -%>
+					<%- result_type = result.class.name.demodulize.downcase -%>
+					<li>
+						<%= render "francis_cms/shared/#{result_type}_hentry", result_type.to_sym => result %>
+					</li>
+				<%- end -%>
+			</ol>
+		<%- else -%>
+			<p>No <%= @content_type.downcase %> found!</p>
+		<%- end -%>
+	</div>
+
+	<footer class="content-footer">
+		<%= render 'francis_cms/shared/author_hcard' %>
+	</footer>
+</div>

--- a/app/views/francis_cms/archives/show.html.erb
+++ b/app/views/francis_cms/archives/show.html.erb
@@ -9,9 +9,9 @@
 		<%- if @results.any? -%>
 			<ol class="entries">
 				<%- @results.each do |result| -%>
-					<%- result_type = result.class.name.demodulize.downcase -%>
+					<%- result_resource_type = resource_type.singularize -%>
 					<li>
-						<%= render "francis_cms/shared/#{result_type}_hentry", result_type.to_sym => result %>
+						<%= render "francis_cms/shared/#{result_resource_type}_hentry", result_resource_type.to_sym => result %>
 					</li>
 				<%- end -%>
 			</ol>

--- a/app/views/francis_cms/archives/show.html.erb
+++ b/app/views/francis_cms/archives/show.html.erb
@@ -1,8 +1,8 @@
-<%- @page_title = "#{@resource_type} Archives: #{@year}" -%>
+<%- @page_title = "#{resource_type.capitalize} Archives: #{@year}" -%>
 
 <div class="h-feed">
 	<header class="content-header">
-		<h1 class="p-name"><%= @resource_type %> Archives: <%= @year %></h1>
+		<h1 class="p-name"><%= resource_type.capitalize %> Archives: <%= @year %></h1>
 	</header>
 
 	<div class="content-container">
@@ -16,7 +16,7 @@
 				<%- end -%>
 			</ol>
 		<%- else -%>
-			<p>No <%= @resource_type.downcase %> found!</p>
+			<p>No <%= resource_type %> found!</p>
 		<%- end -%>
 	</div>
 

--- a/app/views/francis_cms/archives/show.html.erb
+++ b/app/views/francis_cms/archives/show.html.erb
@@ -1,8 +1,8 @@
-<%- @page_title = "#{@content_type} Archives: #{@year}" -%>
+<%- @page_title = "#{@resource_type} Archives: #{@year}" -%>
 
 <div class="h-feed">
 	<header class="content-header">
-		<h1 class="p-name"><%= @content_type %> Archives: <%= @year %></h1>
+		<h1 class="p-name"><%= @resource_type %> Archives: <%= @year %></h1>
 	</header>
 
 	<div class="content-container">
@@ -16,7 +16,7 @@
 				<%- end -%>
 			</ol>
 		<%- else -%>
-			<p>No <%= @content_type.downcase %> found!</p>
+			<p>No <%= @resource_type.downcase %> found!</p>
 		<%- end -%>
 	</div>
 

--- a/app/views/francis_cms/links/index.html.erb
+++ b/app/views/francis_cms/links/index.html.erb
@@ -20,7 +20,7 @@
 
 			<%= will_paginate @links %>
 
-			<p class="highlight"><b>Paginated lists of content not your style?</b> <%= link_to 'Browse the Links Archives by year', archives_links_path %>.</p>
+			<%= render 'francis_cms/shared/archives_promo', resource_type: 'links', url: archives_links_path %>
 		<%- else -%>
 			<p>No links found!</p>
 		<%- end -%>

--- a/app/views/francis_cms/links/index.html.erb
+++ b/app/views/francis_cms/links/index.html.erb
@@ -19,6 +19,8 @@
 			</ol>
 
 			<%= will_paginate @links %>
+
+			<p class="highlight"><b>Paginated lists of content not your style?</b> <%= link_to 'Browse the Links Archives by year', archives_links_path %>.</p>
 		<%- else -%>
 			<p>No links found!</p>
 		<%- end -%>

--- a/app/views/francis_cms/links/index.html.erb
+++ b/app/views/francis_cms/links/index.html.erb
@@ -20,7 +20,7 @@
 
 			<%= will_paginate @links %>
 
-			<%= render 'francis_cms/shared/archives_promo', resource_type: 'links', url: archives_links_path %>
+			<%= render 'francis_cms/shared/archives_promo', url: archives_links_path %>
 		<%- else -%>
 			<p>No links found!</p>
 		<%- end -%>

--- a/app/views/francis_cms/posts/index.html.erb
+++ b/app/views/francis_cms/posts/index.html.erb
@@ -20,7 +20,7 @@
 
 			<%= will_paginate @posts %>
 
-			<p class="highlight"><b>Paginated lists of content not your style?</b> <%= link_to 'Browse the Posts Archives by year', archives_posts_path %>.</p>
+			<%= render 'francis_cms/shared/archives_promo', resource_type: 'posts', url: archives_posts_path %>
 		<%- else -%>
 			<p>No posts found!</p>
 		<%- end -%>

--- a/app/views/francis_cms/posts/index.html.erb
+++ b/app/views/francis_cms/posts/index.html.erb
@@ -20,7 +20,7 @@
 
 			<%= will_paginate @posts %>
 
-			<%= render 'francis_cms/shared/archives_promo', resource_type: 'posts', url: archives_posts_path %>
+			<%= render 'francis_cms/shared/archives_promo', url: archives_posts_path %>
 		<%- else -%>
 			<p>No posts found!</p>
 		<%- end -%>

--- a/app/views/francis_cms/posts/index.html.erb
+++ b/app/views/francis_cms/posts/index.html.erb
@@ -19,6 +19,8 @@
 			</ol>
 
 			<%= will_paginate @posts %>
+
+			<p class="highlight"><b>Paginated lists of content not your style?</b> <%= link_to 'Browse the Posts Archives by year', archives_posts_path %>.</p>
 		<%- else -%>
 			<p>No posts found!</p>
 		<%- end -%>

--- a/app/views/francis_cms/shared/_archives_promo.html.erb
+++ b/app/views/francis_cms/shared/_archives_promo.html.erb
@@ -1,0 +1,3 @@
+<p class="highlight">
+	<b>Looking for more great <%= resource_type %> organized by year?</b> <%= link_to 'Browse the archives', url, rel: 'archives' %>.
+</p>

--- a/app/views/francis_cms/tags/index.html.erb
+++ b/app/views/francis_cms/tags/index.html.erb
@@ -19,7 +19,6 @@
 				</dd>
 			<%- end -%>
 		</dl>
-
 	<%- else -%>
 		<p>No tags found!</p>
 	<%- end -%>

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -16,7 +16,7 @@ FriendlyId.defaults do |config|
   # undesirable to allow as slugs. Edit this list as needed for your app.
   config.use :reserved
 
-  config.reserved_words = %w(admin assets create destroy edit images index javascripts login logout new rss session show stylesheets update users)
+  config.reserved_words = %w(admin archives assets create destroy edit images index javascripts login logout new rss session show stylesheets update users)
 
   #  ## Friendly Finders
   #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 FrancisCms::Engine.routes.draw do
   resources :links, :posts do
     resources :syndications, only: [:create, :destroy]
+
+    get 'archives',       on: :collection, to: 'archives#index'
+    get 'archives/:year', on: :collection, to: 'archives#show', constraints: { year: /\d{4}/ }, as: 'archives_yearly'
   end
 
   resources :tags, only: [:index, :show]

--- a/lib/francis_cms/concerns/models/publishable.rb
+++ b/lib/francis_cms/concerns/models/publishable.rb
@@ -24,7 +24,7 @@ module FrancisCms::Concerns::Models::Publishable
     end
 
     def for_year(year)
-      exclude_drafts.where('published_at >= ? AND published_at <= ?', "#{year}0101", "#{year}1231")
+      exclude_drafts.where('extract(year from published_at)::integer = ?', year)
     end
 
     def years

--- a/lib/francis_cms/concerns/models/publishable.rb
+++ b/lib/francis_cms/concerns/models/publishable.rb
@@ -28,7 +28,7 @@ module FrancisCms::Concerns::Models::Publishable
     end
 
     def years
-      select('extract(year from published_at)::integer as year').distinct.map(&:year).sort
+      exclude_drafts.select('extract(year from published_at)::integer as year').distinct.map(&:year).sort
     end
   end
 

--- a/lib/francis_cms/concerns/models/publishable.rb
+++ b/lib/francis_cms/concerns/models/publishable.rb
@@ -22,6 +22,14 @@ module FrancisCms::Concerns::Models::Publishable
         exclude_drafts.page(opts[:page]).order('published_at DESC')
       end
     end
+
+    def for_year(year)
+      exclude_drafts.where('published_at >= ? AND published_at <= ?', "#{year}0101", "#{year}1231")
+    end
+
+    def years
+      select('extract(year from published_at)::integer as year').distinct.map(&:year).sort
+    end
   end
 
   def newer


### PR DESCRIPTION
For each publishable content type (currently Links and Posts), add yearly archive pages.

URLs are:

- `/:content_type/archives` which shows a list of years of available content.
- `/:content_type/archives/:year` which shows a single-page list of all content published that year.

This PR resolves #31.